### PR TITLE
Publish the scoverage summary even when the build fails

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,10 @@ jobs:
           apps: sbt
           jvm: temurin:${{ inputs.java-version }}
       - run: ./test.sh
-      - if: ${{ inputs.publish-scoverage-summary }}
-        uses: h8io/gha/actions/publish-scoverage-summary@v3
+      # A build may fail on a coverage gate, and the report explaining why it failed is exactly what has to reach the
+      # pull request. A plain `if: ${{ inputs.publish-scoverage-summary }}` still carries the implicit `success()`,
+      # so the comment would never appear in that case; `!cancelled()` drops it while keeping cancelled runs silent.
+      - if: ${{ !cancelled() && inputs.publish-scoverage-summary }}
+        uses: h8io/gha/actions/publish-scoverage-summary@v4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/actions/publish-scoverage-summary/action.yaml
+++ b/actions/publish-scoverage-summary/action.yaml
@@ -31,40 +31,35 @@ runs:
       run: |
         set -euo pipefail
         shopt -s globstar nullglob
-        SUMMARIES=(./**/target/**/scoverage-summary/gfm.md)
-        mapfile -d '' REPORTS < <(find . -type d -path '*/target/*/scoverage-report' -print0)
-        echo "summaries=${#SUMMARIES[@]}" >> "$GITHUB_OUTPUT"
-        echo "reports=${#REPORTS[@]}" >> "$GITHUB_OUTPUT"
-        echo "Found ${#SUMMARIES[@]} summary file(s) and ${#REPORTS[@]} report directory(ies)"
-        if (( ${#SUMMARIES[@]} == 0 && ${#REPORTS[@]} == 0 )); then
+        summaries=(./**/target/**/scoverage-summary/gfm.md)
+        mapfile -d '' reports < <(find . -type d -path '*/target/*/scoverage-report' -print0)
+        echo "summaries=${#summaries[@]}" >> "$GITHUB_OUTPUT"
+        echo "reports=${#reports[@]}" >> "$GITHUB_OUTPUT"
+        echo "Found ${#summaries[@]} summary file(s) and ${#reports[@]} report directory(ies)"
+        if (( ${#summaries[@]} == 0 && ${#reports[@]} == 0 )); then
           echo "::warning::No scoverage output found, nothing to publish"
         fi
     - name: Create scoverage summary
       if: ${{ github.event.pull_request && steps.scoverage.outputs.summaries != '0' }}
       shell: bash
-      env:
-        SUMMARY_FILE: ${{ inputs.summary-file }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         set -euo pipefail
         shopt -s globstar nullglob
-        SUMMARIES=(./**/target/**/scoverage-summary/gfm.md)
-        mapfile -t SORTED < <(printf '%s\n' "${SUMMARIES[@]}" | sort)
-        echo "# $HEAD_SHA" > "$SUMMARY_FILE"
-        cat "${SORTED[@]}" >> "$SUMMARY_FILE"
+        summaries=(./**/target/**/scoverage-summary/gfm.md)
+        mapfile -t sorted < <(printf '%s\n' "${summaries[@]}" | sort)
+        echo "# ${{ github.event.pull_request.head.sha }}" > "${{ inputs.summary-file }}"
+        cat "${sorted[@]}" >> "${{ inputs.summary-file }}"
     - name: Collect reports
       if: ${{ steps.scoverage.outputs.reports != '0' }}
       shell: bash
-      env:
-        REPORT_PATH: ${{ inputs.report-path }}
       run: |
         set -euo pipefail
-        rm -rf "$REPORT_PATH"
-        mkdir -p "$REPORT_PATH"
+        rm -rf "${{ inputs.report-path }}"
+        mkdir -p "${{ inputs.report-path }}"
         mapfile -d '' dirs < <(find . -type d -path '*/target/*/scoverage-report' -print0)
         for d in "${dirs[@]}"; do
           rel="${d#./}"
-          out="$REPORT_PATH/$(printf %s "$rel" | sed -E 's#(^|/)target/#\1#')"
+          out="${{ inputs.report-path }}/$(printf %s "$rel" | sed -E 's#(^|/)target/#\1#')"
           mkdir -p "$out"
           rsync -a --delete "$d/" "$out/"
           echo "Copied: $d -> $out"
@@ -81,21 +76,14 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        SUMMARY_FILE: ${{ inputs.summary-file }}
-        REPORTS: ${{ steps.scoverage.outputs.reports }}
-        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         set -euo pipefail
         if [ -z "${GITHUB_TOKEN:-}" ]; then
           echo "GitHub token undefined or empty" >&2
           exit 1
         fi
-        # The link is only worth adding when there is an artifact behind it
-        if [ "$REPORTS" != "0" ]; then
-          {
-            echo
-            echo "[Download full HTML report]($RUN_URL#artifacts)"
-          } >> "$SUMMARY_FILE"
-        fi
-        gh pr comment "$PR_NUMBER" --body-file "$SUMMARY_FILE"
+        {
+          echo
+          echo "[Download full HTML report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)"
+        } >> "${{ inputs.summary-file }}"
+        gh pr comment "${{ github.event.pull_request.number }}" --body-file "${{ inputs.summary-file }}"

--- a/actions/publish-scoverage-summary/action.yaml
+++ b/actions/publish-scoverage-summary/action.yaml
@@ -22,47 +22,80 @@ inputs:
 runs:
   using: composite
   steps:
+    # The caller runs this action even when the build has failed, so that a coverage gate still gets its report into
+    # the pull request. A build which failed before generating anything leaves nothing behind, and the action then has
+    # to stay quiet instead of adding a second, misleading failure to an already red job.
+    - name: Look for scoverage output
+      id: scoverage
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s globstar nullglob
+        SUMMARIES=(./**/target/**/scoverage-summary/gfm.md)
+        mapfile -d '' REPORTS < <(find . -type d -path '*/target/*/scoverage-report' -print0)
+        echo "summaries=${#SUMMARIES[@]}" >> "$GITHUB_OUTPUT"
+        echo "reports=${#REPORTS[@]}" >> "$GITHUB_OUTPUT"
+        echo "Found ${#SUMMARIES[@]} summary file(s) and ${#REPORTS[@]} report directory(ies)"
+        if (( ${#SUMMARIES[@]} == 0 && ${#REPORTS[@]} == 0 )); then
+          echo "::warning::No scoverage output found, nothing to publish"
+        fi
     - name: Create scoverage summary
-      if: ${{ github.event.pull_request }}
+      if: ${{ github.event.pull_request && steps.scoverage.outputs.summaries != '0' }}
       shell: bash
+      env:
+        SUMMARY_FILE: ${{ inputs.summary-file }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         set -euo pipefail
-        shopt -s globstar
-        echo "# ${{ github.event.pull_request.head.sha }}" > "${{ inputs.summary-file }}"
-        cat $(ls ./**/target/**/scoverage-summary/gfm.md | sort) >> "${{ inputs.summary-file }}"
+        shopt -s globstar nullglob
+        SUMMARIES=(./**/target/**/scoverage-summary/gfm.md)
+        mapfile -t SORTED < <(printf '%s\n' "${SUMMARIES[@]}" | sort)
+        echo "# $HEAD_SHA" > "$SUMMARY_FILE"
+        cat "${SORTED[@]}" >> "$SUMMARY_FILE"
     - name: Collect reports
+      if: ${{ steps.scoverage.outputs.reports != '0' }}
       shell: bash
+      env:
+        REPORT_PATH: ${{ inputs.report-path }}
       run: |
         set -euo pipefail
-        rm -rf "${{ inputs.report-path }}"
-        mkdir -p "${{ inputs.report-path }}"
+        rm -rf "$REPORT_PATH"
+        mkdir -p "$REPORT_PATH"
         mapfile -d '' dirs < <(find . -type d -path '*/target/*/scoverage-report' -print0)
-        (( ${#dirs[@]} )) || { echo "No scoverage-report directories found"; exit 1; }  
         for d in "${dirs[@]}"; do
           rel="${d#./}"
-          out="${{ inputs.report-path }}/$(printf %s "$rel" | sed -E 's#(^|/)target/#\1#')"
+          out="$REPORT_PATH/$(printf %s "$rel" | sed -E 's#(^|/)target/#\1#')"
           mkdir -p "$out"
           rsync -a --delete "$d/" "$out/"
           echo "Copied: $d -> $out"
         done
     - name: Upload coverage artifact
+      if: ${{ steps.scoverage.outputs.reports != '0' }}
       uses: actions/upload-artifact@v7
       with:
         name: scoverage-report
         path: ${{ inputs.report-path }}
         retention-days: ${{ inputs.retention-days }}
     - name: Publish scoverage summary
-      if: ${{ github.event.pull_request }}
+      if: ${{ github.event.pull_request && steps.scoverage.outputs.summaries != '0' }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        SUMMARY_FILE: ${{ inputs.summary-file }}
+        REPORTS: ${{ steps.scoverage.outputs.reports }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
+        set -euo pipefail
         if [ -z "${GITHUB_TOKEN:-}" ]; then
           echo "GitHub token undefined or empty" >&2
           exit 1
         fi
-        {
-          echo
-          echo "[Download full HTML report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)"
-        } >> "${{ inputs.summary-file }}"
-        gh pr comment "${{ github.event.pull_request.number }}" --body-file ${{ inputs.summary-file }}
+        # The link is only worth adding when there is an artifact behind it
+        if [ "$REPORTS" != "0" ]; then
+          {
+            echo
+            echo "[Download full HTML report]($RUN_URL#artifacts)"
+          } >> "$SUMMARY_FILE"
+        fi
+        gh pr comment "$PR_NUMBER" --body-file "$SUMMARY_FILE"


### PR DESCRIPTION
## Summary

`sbt-scoverage-summary` can now fail a build on a coverage gate, and the report explaining *why* it failed is precisely what has to reach the pull request. It never did:

```yaml
- if: ${{ inputs.publish-scoverage-summary }}
```

An `if` without a status check function still carries an implicit `success()`, so the step was skipped on every failed run. `!cancelled()` drops that implicit condition while keeping cancelled runs quiet — unlike `always()`, there is no point commenting on a run somebody cancelled.

The job itself stays red either way; only the comment is new.

## Consequence: the action is now reached by builds that produced nothing

A build that dies in `scalafmtCheck` or in compilation leaves no `gfm.md` and no `scoverage-report`. The action used to fail hard in that case — `ls` on a non-matching glob under `set -e`, and an explicit `exit 1` when no report directory was found. On a job that is already red, that only buries the real error under a second, unrelated one.

So the action now establishes what exists before doing anything, and skips the steps that need it:

| situation | comment | artifact | action outcome |
|---|---|---|---|
| build green | posted | uploaded | success |
| build failed on the coverage gate | posted | uploaded | success, job still red |
| build failed before generating anything | — | — | success, warning annotation |

The lost `exit 1` used to catch one real case: a green build configured with `publish-scoverage-summary: true` but producing no coverage. That is a one-off setup mistake, and it now surfaces as a warning annotation plus an absent comment rather than a failure.

## Incidental

- `cat $(ls … | sort)` becomes an array, so it no longer depends on word splitting and no longer breaks on a glob that matches nothing — the same failure mode the guard above addresses.
- `--body-file` gets its argument quoted, and the publishing step gets the `set -euo pipefail` its siblings already had.

## The version bump

`publish-scoverage-summary@v3` becomes `@v4`. The workflow is consumed as `test.yaml@v4`, so leaving the action at `v3` would pair the new `!cancelled()` with the *old* action — the one combination that misbehaves, since the old action fails hard exactly in the case the new condition creates. At `@v4` both move together when the floating tag advances.

This does mean the change is only fully live once a `v4.0.3` tag moves `v4`; merging alone leaves `main` referencing an action version that does not yet contain this commit.

## Test plan

- `actionlint -shellcheck=shellcheck` clean over the workflows, same invocation as the linter workflow
- the composite action's `run` bodies extracted and shellchecked separately, since `actionlint` does not descend into composite actions — clean
- action YAML parses and all five steps resolve
- `@action-validator/cli` not run locally, `npx` is unavailable here; it runs in the linter workflow on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)