### PR TITLE
Point the internal references at the v5 series

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,6 @@ jobs:
       # pull request. A plain `if: ${{ inputs.publish-scoverage-summary }}` still carries the implicit `success()`,
       # so the comment would never appear in that case; `!cancelled()` drops it while keeping cancelled runs silent.
       - if: ${{ !cancelled() && inputs.publish-scoverage-summary }}
-        uses: h8io/gha/actions/publish-scoverage-summary@v4
+        uses: h8io/gha/actions/publish-scoverage-summary@v5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #33. `v5.0.0` has already been tagged at `5748053`, and it carries the pairing #33 set out to avoid: its `test.yaml` publishes on failure while still calling `publish-scoverage-summary@v4`, and `v4` resolves to `v4.0.2`, the copy that fails hard when there is nothing to publish.

So on `test.yaml@v5` today, a build that dies before producing coverage gets its real error followed by `ls: cannot access './**/target/**/scoverage-summary/gfm.md'` from the publish step. **This wants a `v5.0.1` once merged.**

Every internal reference now names `v5`:

| workflow | action | before | after |
|---|---|---|---|
| `test.yaml` | `publish-scoverage-summary` | `@v4` (from #33) | `@v5` |
| `release.yaml` | `check-sonatype-token` | `@v3` | `@v5` |
| `snapshot.yaml` | `check-sonatype-token` | `@v3` | `@v5` |
| `check-sonatype-token.yaml` | `check-sonatype-token` | `@v3` | `@v5` |
| `floating-tags.yaml` | `floating-tags` | `@v2` | `@v5` |

### Why v5 at all

The repository's own history sets the convention — every consumer-visible behaviour change has taken a major, and minor is essentially unused (one instance, `v1.1.0`):

| bump | what it was |
|---|---|
| `v2.0.0` | actions moved under `actions/` |
| `v3.0.0` | `publish-scoverage-summary/action.yaml` reworked (+39/−9) plus a `test.yaml` change |
| `v4.0.0` | one line in `release.yaml`, the sbt command requiring sbt 2.0 |

\#33 is the structural twin of `v3.0.0`: the same action reworked, alongside a `test.yaml` behaviour change.

### The one reference with a rule attached

`floating-tags` is safe at `@v5` — a reference only fails to resolve when it names the series *being created*, and `v5` already exists. What it must never do is follow a bump to `@v6` in the commit that becomes `v6.0.0`. That workflow runs on the push of that very tag, so `@v6` would resolve to nothing: the alias appears seconds later, as a result of this run. The job fails, `v6` and `v6.0` are never created, every consumer pinning `@v6` resolves nothing, and pushing `v6.0.1` fails identically because that commit carries the same unresolvable reference. Recovery would mean creating the alias by hand.

A comment now says so next to the reference, which is the only place anyone will be looking when the next major comes around.

### A note on the release dance

Chasing the references in a `vX.0.1` is only necessary for `floating-tags`, which resolves at tag-push time. Every other reference resolves when a consumer calls the workflow, which is necessarily after the alias exists — so a forward reference to `@vX` inside a workflow tagged `vX.0.0` is fine. Next major, the new references can go straight into `vX.0.0` for everything except this one.

## Test plan

- `actionlint -shellcheck=shellcheck` clean, same invocation as the linter workflow
- `v3`, `v4` and `v5` verified against the remote to resolve to `v3.0.12`, `v4.0.2` and `5748053`, so the floating-tag mechanism does move as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)