### PR TITLE
Point the remaining internal references at v5

### DIFF
--- a/.github/workflows/check-sonatype-token.yaml
+++ b/.github/workflows/check-sonatype-token.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: h8io/gha/actions/check-sonatype-token@v3
+      - uses: h8io/gha/actions/check-sonatype-token@v5
         with:
           username: ${{ secrets.SONATYPE_USERNAME }}
           password: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/floating-tags.yaml
+++ b/.github/workflows/floating-tags.yaml
@@ -12,4 +12,8 @@ jobs:
   floating-tags:
     runs-on: ubuntu-latest
     steps:
-      - uses: h8io/gha/actions/floating-tags@v2
+      # Keep this at least one major behind, never on the series being released. This workflow runs on the push of
+      # the very tag whose aliases it creates, so a reference to that series resolves to nothing: the alias appears
+      # seconds later, as the result of this run. The job would fail, the alias would never be created, and the next
+      # patch tag would fail identically.
+      - uses: h8io/gha/actions/floating-tags@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Check Sonatype token
-        uses: h8io/gha/actions/check-sonatype-token@v3
+        uses: h8io/gha/actions/check-sonatype-token@v5
         with:
           username: ${{ secrets.SONATYPE_USERNAME }}
           password: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Check Sonatype token
-        uses: h8io/gha/actions/check-sonatype-token@v3
+        uses: h8io/gha/actions/check-sonatype-token@v5
         with:
           username: ${{ secrets.SONATYPE_USERNAME }}
           password: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
## Summary

#35 was merged with only its first commit, so `test.yaml` moved to `publish-scoverage-summary@v5` while the rest stayed behind. This finishes the job.

| workflow | action | before | after |
|---|---|---|---|
| `release.yaml` | `check-sonatype-token` | `@v3` | `@v5` |
| `snapshot.yaml` | `check-sonatype-token` | `@v3` | `@v5` |
| `check-sonatype-token.yaml` | `check-sonatype-token` | `@v3` | `@v5` |
| `floating-tags.yaml` | `floating-tags` | `@v2` | `@v5` |

These had been drifting since `v2.0.0`, which was harmless only because neither action had changed since.

## The one reference with a rule attached

`floating-tags` is safe at `@v5` — a reference only fails to resolve when it names the series *being created*, and `v5` already exists. What it must never do is follow a bump to `@v6` in the commit that becomes `v6.0.0`. That workflow runs on the push of that very tag, so `@v6` would resolve to nothing: the alias appears seconds later, as a result of this run. The job fails, `v6` and `v6.0` are never created, every consumer pinning `@v6` resolves nothing, and pushing `v6.0.1` fails identically because that commit carries the same unresolvable reference. Recovery would mean creating the alias by hand.

A comment now says so next to the reference, which is the only place anyone will be looking when the next major comes around.

## Still outstanding from #33

`v5.0.0` is tagged at `5748053`, whose `test.yaml` publishes on failure while calling `publish-scoverage-summary@v4` — the copy that fails hard when there is nothing to publish. A build that dies before producing coverage therefore gets its real error followed by `ls: cannot access './**/target/**/scoverage-summary/gfm.md'`. **`v5.0.1` is what closes that**, and it wants this merged first so the token check does not need a third pass.

## Test plan

- `actionlint -shellcheck=shellcheck` clean, same invocation as the linter workflow
- every internal reference re-listed after the change; all five now name `v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)