### PR TITLE
Let the release own the documentation deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,22 +9,17 @@ on:
         description: Java version
         type: number
         default: 17
-      debug:
-        description: Enable debug mode for troubleshooting
+      publish-pages:
+        description: Deploy the documentation site left in target/pages by ./release.sh to GitHub Pages?
         type: boolean
         default: false
-      verbose:
-        description: Enable verbose output for debugging
-        type: boolean
-        default: false
-
-permissions:
-  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
     steps:
       - name: Check Sonatype token
         uses: h8io/gha/actions/check-sonatype-token@v5
@@ -60,9 +55,19 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: |
-          set -o pipefail
-          sbt  ${{ inputs.debug && '-debug' || '' }} ${{ inputs.verbose && '-v' || '' }} "cleanFull; +test; ci-release"
+        run: ./release.sh
+
+      # The site comes out of the same script, and the same build, that published the artifact, so all that is left
+      # here is to carry it over to the deployment job. This step is where the ordering is enforced: it is an ordinary
+      # step with the implicit `success()`, so a release that failed uploads nothing and `pages` finds nothing to
+      # deploy.
+      - name: Upload the documentation site
+        if: ${{ inputs.publish-pages }}
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: target/pages
+          # Long enough that re-running the deployment job on its own stays an option for a while after the release.
+          retention-days: 7
 
       - name: Create GitHub release
         env:
@@ -70,3 +75,28 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           gh release create "$TAG" --title "$TAG" --generate-notes --latest
+
+  # The deployment is a job of this workflow rather than a workflow of its own because `needs:` orders jobs within one
+  # workflow file and nothing orders two workflows started by the same tag. Its permissions are declared on the job
+  # instead of the workflow, so that a caller leaving `publish-pages` off never has to grant them.
+  pages:
+    needs: release
+    if: ${{ inputs.publish-pages }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # A repository has a single Pages site, so two deployments must not overlap. Cancelling the one already running is
+    # not the way to achieve that here: it belongs to a release that has already succeeded, and cancelling it leaves
+    # the site on the previous version while the release reports success.
+    concurrency:
+      group: gha:pages~${{ github.repository }}
+      cancel-in-progress: false
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -39,4 +39,4 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: sbt +clean +compile ci-release
+        run: ./snapshot.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,17 +44,17 @@ that workflow to the series being released, or the fix ships dead.
 Everything moves together under one tag, so workflows and actions cannot be versioned independently.
 
 Every entry point that builds anything does it by running a script from the caller's root, named after the
-workflow that runs it: `./test.sh`, `./release.sh`. The caller owns the build and the build tool; this repo
-provides the runner, the Coursier cache, the JVM, the secrets and the policy around them. No sbt command is
-written down here, and none should be — that is what pinned `stages` to the `v3` series for as long as
-`release.yaml` spelled out `cleanFull`.
+workflow that runs it: `./test.sh`, `./release.sh`, `./snapshot.sh`. The caller owns the build and the build
+tool; this repo provides the runner, the Coursier cache, the JVM, the secrets and the policy around them. No
+sbt command is written down here, and none should be — that is what pinned `stages` to the `v3` series for
+as long as `release.yaml` spelled out `cleanFull`.
 
 - `test.yaml` runs `./test.sh`, then invokes `publish-scoverage-summary`, which expects
   `sbt-scoverage-summary` to have produced `**/target/**/scoverage-summary/gfm.md`.
 - `release.yaml` refuses to release unless the pushed tag points at the exact commit of the default
   branch, then runs `./release.sh`. With `publish-pages` on, that script is also expected to leave the
-  documentation site in `target/pages`. It needs the PGP and Sonatype secrets, which are passed through
-  `secrets: inherit` from the caller.
+  documentation site in `target/pages`. `snapshot.yaml` runs `./snapshot.sh`. Both need the PGP and
+  Sonatype secrets, which are passed through `secrets: inherit` from the caller.
 - `scala-steward.yaml` authenticates as a GitHub App (`H8IO_APP_ID` / `H8IO_APP_PK`), not as a user.
 
 Each workflow declares its own `permissions`; `test.yaml` needs `pull-requests: write` purely to post the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Shared CI for the H8IO Scala projects: reusable workflows under `.github/workflows/` and composite
 actions under `actions/`. Nothing here builds or runs on its own — every entry point exists to be
 called from another repository, e.g. `h8io/sbt-scoverage-summary` (a sibling checkout at `../sbt-scoverage-summary`),
-whose workflows are three-line stubs delegating to `h8io/gha/.github/workflows/test.yaml@v4`.
+whose workflows are three-line stubs delegating to `h8io/gha/.github/workflows/test.yaml@v5`.
 
 ## Commands
 
@@ -43,18 +43,49 @@ that workflow to the series being released, or the fix ships dead.
 
 Everything moves together under one tag, so workflows and actions cannot be versioned independently.
 
-## Contracts with the calling repository
+Every entry point that builds anything does it by running a script from the caller's root, named after the
+workflow that runs it: `./test.sh`, `./release.sh`. The caller owns the build and the build tool; this repo
+provides the runner, the Coursier cache, the JVM, the secrets and the policy around them. No sbt command is
+written down here, and none should be — that is what pinned `stages` to the `v3` series for as long as
+`release.yaml` spelled out `cleanFull`.
 
-- `test.yaml` runs `./test.sh` from the caller's root — the caller owns the whole build, this repo only
-  provides the runner, the Coursier cache and the JVM. It then invokes `publish-scoverage-summary`, which
-  expects `sbt-scoverage-summary` to have produced `**/target/**/scoverage-summary/gfm.md`.
+- `test.yaml` runs `./test.sh`, then invokes `publish-scoverage-summary`, which expects
+  `sbt-scoverage-summary` to have produced `**/target/**/scoverage-summary/gfm.md`.
 - `release.yaml` refuses to release unless the pushed tag points at the exact commit of the default
-  branch, then runs `sbt "cleanFull; +test; ci-release"`. It needs the PGP and Sonatype secrets, which are
-  passed through `secrets: inherit` from the caller.
+  branch, then runs `./release.sh`. With `publish-pages` on, that script is also expected to leave the
+  documentation site in `target/pages`. It needs the PGP and Sonatype secrets, which are passed through
+  `secrets: inherit` from the caller.
 - `scala-steward.yaml` authenticates as a GitHub App (`H8IO_APP_ID` / `H8IO_APP_PK`), not as a user.
 
 Each workflow declares its own `permissions`; `test.yaml` needs `pull-requests: write` purely to post the
 coverage comment.
+
+### Documentation is deployed by the release, not next to it
+
+A tag push used to start the release and the site deployment as two unrelated workflows, so a release that
+failed — wrong tag, expired Sonatype token, red `+test` — still left the site describing a version that
+never reached Maven Central, and with the site unversioned there was nothing to fall back to.
+
+The site is therefore built by the same `./release.sh`, in the same sbt run, that publishes the artifact. A
+separate workflow would mean a second checkout, a second JVM and a second full build, producing
+documentation for a commit the first build has already compiled. What is left for this repo is to upload
+`target/pages` and deploy it from a job that `needs: release`. The upload is an ordinary step carrying the
+implicit `success()`, and that is the entire gate: a release that failed uploads nothing, so the deployment
+has nothing to deploy.
+
+`publish-pages` is off by default — a project whose documentation is a `README.md` in the root has nothing
+to deploy. The `pages: write` and `id-token: write` the deployment needs are declared on that job alone and
+never at the workflow level, so that callers leaving the flag off do not have to grant them. For the same
+reason there is no `configure-pages` step: it would have to run in the release job, where it would need
+`pages: read` in order to produce outputs that a site built by sbt does not read anyway.
+
+Deploying documentation without releasing is deliberately not possible, since an unversioned site describes
+whatever the latest release is. When the release succeeded and only the deployment failed, re-run the
+`pages` job of that run — the uploaded site is retained for a week so that this keeps working.
+
+The reverse gap stays open by design: `gh release create` runs before the deployment, so a failed deploy
+leaves a released artifact next to an older site. Documentation lagging behind the artifact is the harmless
+direction; documentation running ahead of it is not.
 
 ## Action-specific notes
 


### PR DESCRIPTION
## Why

A tag push starts `Release` and `Publish pages` as two unrelated workflows. Nothing orders them and nothing connects them, so a release that fails — tag not on the default branch, expired Sonatype token, red `+test` — still gets its documentation published, describing a version that never reached Maven Central. The site is unversioned, so there is no earlier copy to fall back to.

## What changed

- **The site is built by `./release.sh`, in the same sbt run that publishes the artifact.** A workflow of its own would mean a second checkout, a second JVM and a second full build, producing documentation for a commit the first build has already compiled.
- **The gate is the upload.** `actions/upload-pages-artifact` is an ordinary step in the release job, carrying the implicit `success()`, so a failed release uploads nothing and the `pages` job — which `needs: release` — has nothing to deploy. `needs:` orders jobs within one workflow file and nothing orders two workflows started by the same tag, which is why this lives here.
- **`publish-pages` input, default `false`.** A project documented by a `README.md` in the root has nothing to deploy, so `sbt-scoverage-summary` and the rest are untouched.
- **No `configure-pages`.** It would now have to run in the release job, where it would need `pages: read` to produce outputs that a site built by sbt never reads.
- **No sbt commands are left in this repository.** `release.yaml` runs `./release.sh` and `snapshot.yaml` runs `./snapshot.sh`, matching what `test.yaml` already did with `./test.sh`.

## The pin this dissolves

`stages` sits on `release.yaml@v3` because from v4 the command here is `cleanFull`, an sbt 2 command, while that repository builds on sbt 1. Once the caller owns the command, the caller owns the sbt version too. `debug` and `verbose` go away with it — they existed only to inject flags into a command that no longer lives here.

Snapshot creates no pin of its own (`+clean +compile ci-release` is valid on both sbt 1 and sbt 2), but leaving it behind would keep the rule half-stated.

## Breaking, so this is `v6`

- Callers of `release.yaml` need a `./release.sh`; callers of `snapshot.yaml` need a `./snapshot.sh`.
- Callers setting `publish-pages: true` need `pages: write` and `id-token: write` in their stub's `permissions`, and their `./release.sh` must leave the site in `target/pages`.
- Publishing documentation without releasing is no longer possible. That is deliberate for an unversioned site, and when only the deployment failed the `pages` job of that run can be re-run on its own — the uploaded site is retained for a week.

## What the first real release will confirm

Whether a caller leaving `publish-pages` off is genuinely free of the Pages permissions. They are declared on the skipped job rather than on the workflow precisely so they are never requested, but "permissions can only be maintained or reduced" is documented without saying when the check runs. If it turns out to be eager, the fallback is one line in each stub and nothing about the design changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)