### PR TITLE
Make the test timeout a ceiling again

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,11 @@ on:
   workflow_call:
     inputs:
       timeout-minutes:
+        # A ceiling for a job that has hung, not a budget for one that is working. Five was neither: `stages` runs
+        # for four and a half minutes and was being killed on any slow day.
         description: Maximum time (in minutes) before the job is canceled
         type: number
-        default: 5
+        default: 15
       java-version:
         description: Java version
         type: number

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ as long as `release.yaml` spelled out `cleanFull`.
 Each workflow declares its own `permissions`; `test.yaml` needs `pull-requests: write` purely to post the
 coverage comment.
 
+`timeout-minutes` is a ceiling for a job that has hung, not a budget for one that is working, so it belongs
+several times above the typical run rather than just above it. A caller should normally inherit the default
+and only pass its own when a build is genuinely unlike the rest.
+
 ### Documentation is deployed by the release, not next to it
 
 A tag push used to start the release and the site deployment as two unrelated workflows, so a release that


### PR DESCRIPTION
## Why

Five minutes was never chosen — it spread by copy-paste — and it stopped being a safety net some time ago. Measured across the organisation, against the 300s budget:

| repository | run | of budget |
|---|---|---|
| **stages** | 283–292s | **94–97%** |
| cfg | 201–219s | 67–73% |
| sbt-testkit | 162–175s | 54–58% |
| h8io.g8 | 115–117s | 39% |
| sbt-scoverage-summary | 69–102s | 23–34% |
| xi, sbt-dependencies | 55–98s | < 33% |

`stages` clears the limit by eight to seventeen seconds. That is not a risk for later: a slow day at GitHub, rather than any bug, is enough to kill it.

`timeout-minutes` is meant to cut off a job that has hung, not to measure one that is working, so it belongs several times above the typical run. Fifteen keeps the protection and stops the arithmetic.

## Scope

The default here, plus a note in `CLAUDE.md` about what the setting is for. Callers that pass `timeout-minutes: 5` explicitly keep it until they drop the line — that is the other half, one line each in `stages`, `cfg`, `xi`, `reflect`, `typesafe-config-yaml` and the `h8io.g8` template. The three plugin repositories declare nothing and inherit this.

Non-breaking, so `v6.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)