### PR TITLE
Let the deployment job inherit its permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,10 +84,10 @@ jobs:
     if: ${{ inputs.publish-pages }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
+    # No `permissions:` here on purpose. Declaring them makes the called workflow *request* them, and that request is
+    # validated when the file is parsed — before `if:` is evaluated, so a caller with `publish-pages` off failed to
+    # start at all rather than skipping this job. Inheriting instead means only callers that deploy have to grant
+    # `pages: write` and `id-token: write`, which they already do.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## The breakage

`sbt-testkit` v2.2.0 could not release. Not a job failure — the workflow refused to start:

```
Invalid workflow file
The nested job 'pages' is requesting 'pages: write, id-token: write',
but is only allowed 'pages: none, id-token: none'.
```

This is the question I left open in #37 and said the first real release would answer. It has: **the permission check is eager.** It runs when the workflow file is parsed, before `if:` is evaluated, so declaring permissions on the `pages` job made the called workflow *request* them regardless of `publish-pages`. A caller that does not deploy a site did not skip that job — it failed to start at all.

Every repository on `v6` with `publish-pages` off is affected: `sbt-testkit`, `sbt-dependencies`, `sbt-scoverage-summary`, `xi`, `reflect`, `typesafe-config-yaml`. `stages` and `cfg` released fine only because they grant the permissions.

## The fix

Drop the `permissions:` block from the `pages` job. With nothing declared, the workflow requests nothing and the job inherits whatever the caller granted — so only callers that actually deploy need `pages: write` and `id-token: write`, which both of them already have. The `release` job keeps its explicit `contents: write`, which every caller grants.

Four lines deleted. No consumer changes.

## Verified on a live run

Reasoning is what got this wrong the first time, so this was checked end to end: a throwaway caller granting only `contents: write`, pointing at this branch.

```
job release / release: failure
  1. Set up job:            success
  2. Check Sonatype token:  success
  3. Run actions/checkout:  success
  4. Check tag:             failure     <- a branch is not a tag, as expected
  5-8. …                    skipped
job release / pages:        skipped
```

The workflow **starts**, the `pages` job is **skipped**, and nothing publishes — the run stops at the tag check, well before `./release.sh`. That is the behaviour the design assumed all along.

## After merging

Needs a tag before it reaches anyone. The failed `v2.2.0` run left nothing behind — no GitHub release, nothing on Maven Central, and the tag is no longer on the remote — so that release can simply be tagged again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)